### PR TITLE
Allowing for an alternate root template directory.

### DIFF
--- a/tasks/index.js
+++ b/tasks/index.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
     grunt.registerMultiTask('localizr', 'A preprocessor for Dust.js templates.', function () {
         var done, options, contentPath, bundles, bundleRoot, filesSrc,
             pathName = path.sep + '**' + path.sep + '*.properties',
-            fileRoot = path.join('public', 'templates'),
+            fileRoot = this.options().templateRoot || path.join('public', 'templates'),
             propFile = this.options().contentFile,
             promise;
 

--- a/test/fixtures/client/templates/nested/test.dust
+++ b/test/fixtures/client/templates/nested/test.dust
@@ -1,0 +1,1 @@
+<div>{@pre type="content" key="index.greeting" /}</div>

--- a/test/index.js
+++ b/test/index.js
@@ -10,17 +10,15 @@ test('Grunt-localizr', function (t) {
     process.chdir(path.join(process.cwd(), 'test', 'fixtures'));
     grunt.task.init = function() {};
 
-    grunt.initConfig({
-        localizr: {
-            files: ['public/templates/**/*.dust'],
-            options: {
-                contentPath: ['locales/**/*.properties']
-            }
-        }
-    });
-
     t.test('test a localizr build', function(t) {
-
+        grunt.initConfig({
+            localizr: {
+                files: ['public/templates/**/*.dust'],
+                options: {
+                    contentPath: ['locales/**/*.properties']
+                }
+            }
+        });
 
         require('../tasks/index')(grunt);
         grunt.tasks(['localizr'], {}, function(){
@@ -35,6 +33,34 @@ test('Grunt-localizr', function (t) {
             t.equal('<div>Hello</div>', fs.readFileSync('./tmp/US/en/nested/test.dust', 'utf8'));
             t.equal('<div>Test with no Locale </div>', fs.readFileSync('./tmp/US/en/nested/test1.dust', 'utf8'));
             t.equal('<div>Test with no Locale </div>', fs.readFileSync('./tmp/US/en/nested/test1.dust', 'utf8'));
+
+            rimraf('tmp', function() {
+                t.end();
+            });
+
+        });
+    });
+
+    t.test('test a localizr build with alternate dir structure', function(t) {
+        grunt.initConfig({
+            localizr: {
+                files: ['client/templates/**/*.dust'],
+                options: {
+                    contentPath: ['locales/**/*.properties'],
+                    templateRoot: 'client/templates'
+                }
+            }
+        });
+
+        require('../tasks/index')(grunt);
+        grunt.tasks(['localizr'], {}, function(){
+            //verify the files exist
+            t.equal(true, fs.existsSync('./tmp/ES/es/nested/test.dust'));
+            t.equal(true, fs.existsSync('./tmp/US/en/nested/test.dust'));
+
+            //verify they have expected content
+            t.equal('<div>Hola</div>', fs.readFileSync('./tmp/ES/es/nested/test.dust', 'utf8'));
+            t.equal('<div>Hello</div>', fs.readFileSync('./tmp/US/en/nested/test.dust', 'utf8'));
 
             rimraf('tmp', function() {
                 t.end();


### PR DESCRIPTION
When I run the localizer task on the following dir:
 client/templates
I get a resulting directory structure that prunes off the leading "c":
  tmp/US/en/lient/templates/....
I was expecting:
  tmp/US/en/client/templates/....
I think the problem is in the utils.getRelative() function that prunes off the first character.  I'm guessing it's thinking that the first character will be a directory separator, but for me there is no leading separator, so it just prunes off my leading character.
But, really, in the output directories I don't really want the "client/templates" segments in the path either.  So my PR makes it possible to specify an alternate to the default "public/templates"
