### PR TITLE
Looks like the order in which the tests are executed is causing a failur...

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ var grunt = require('grunt'),
 
 grunt.loadNpmTasks('grunt-force-task');
 test('Grunt-localizr', function (t) {
+    var original = process.cwd();
     process.chdir(path.join(process.cwd(), 'test', 'fixtures'));
     grunt.task.init = function() {};
     require('../tasks/index')(grunt);
@@ -113,6 +114,9 @@ test('Grunt-localizr', function (t) {
         grunt.tasks(['force:localizr'], {}, function() {
             t.end();
         });
+    });
+    t.on('end', function() {
+        process.chdir(original);
     });
 });
 


### PR DESCRIPTION
...e in 0.11 version of node. moving the process.cwd to original value

Looks like it did not fail in node 0.10 coz the other tape test `localeList` executed first. In 0.11 it executed the other way round surfacing the problem of current directory.