### PR TITLE
Limit concurrency in localization with bundles

### DIFF
--- a/tasks/index.js
+++ b/tasks/index.js
@@ -134,7 +134,7 @@ function processWithBundles(srcFile, fileBundles, bundleRoot, options) {
     });
 }
 
-function localize(srcFile, propFile, destFile) {
+var localize = qlimit(function(srcFile, propFile, destFile) {
     var opt = {
             src: srcFile,
             props: propFile
@@ -177,7 +177,7 @@ function localize(srcFile, propFile, destFile) {
     });
 
     return deferred.promise;
-}
+});
 
 var copy = qlimit(function copy(srcFile, destFile) {
     var deferred = BB.pending();


### PR DESCRIPTION
My Kraken project deals with 413 templates and 22883 content property files, and build by `grunt-localizr` fails on OS X as below.

```
Generated  {PROJECT_HOME}/tmp/US/en/foo/bar.dust
Fatal error: UNKNOWN, open 'public/templates/foo/inc/bar.dust'
    Warning:  Use --force to continue.

        Aborted due to warnings.
```

I would like to limit concurrency in localization with bundles as `copy = qlimit(function(srcFile, destFile) {...`. I verified issue is resolved by this change.
